### PR TITLE
Handle Redis Deprecations

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---format=nested
---color

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,41 +7,73 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    ffi (1.1.5)
-    guard (1.4.0)
-      listen (>= 0.4.2)
-      thor (>= 0.14.6)
-    guard-rspec (2.1.0)
-      guard (>= 1.1)
-      rspec (~> 2.11)
-    listen (0.5.3)
-    mock_redis (0.5.4)
-    rake (0.9.2.2)
-    rb-fsevent (0.9.2)
-    rb-inotify (0.8.8)
-      ffi (>= 0.5.0)
-    redis (3.2.0)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.3)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.3)
-    thor (0.16.0)
-    timecop (0.5.2)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    ffi (1.15.5)
+    formatador (1.1.0)
+    guard (2.18.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lumberjack (1.2.8)
+    method_source (1.0.0)
+    mock_redis (0.31.0)
+      ruby2_keywords
+    nenv (0.3.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.0.6)
+    rb-fsevent (0.11.1)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    redis (4.6.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    ruby2_keywords (0.0.5)
+    shellany (0.0.1)
+    thor (1.2.1)
+    timecop (0.9.5)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   fresh_redis!
-  guard-rspec (= 2.1.0)
-  mock_redis (= 0.5.4)
-  rake (= 0.9.2.2)
+  guard-rspec
+  mock_redis
+  rake
   rb-fsevent
   rb-inotify
   rspec
-  timecop (= 0.5.2)
+  timecop
+
+BUNDLED WITH
+   2.3.12

--- a/fresh_redis.gemspec
+++ b/fresh_redis.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'redis'
 
   gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'mock_redis', '0.5.4'
-  gem.add_development_dependency 'guard-rspec', '2.1.0'
-  gem.add_development_dependency 'rake', '0.9.2.2'
-  gem.add_development_dependency 'timecop', '0.5.2'
+  gem.add_development_dependency 'mock_redis'
+  gem.add_development_dependency 'guard-rspec'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'timecop'
 end

--- a/lib/fresh_redis/hash.rb
+++ b/lib/fresh_redis/hash.rb
@@ -3,9 +3,9 @@ class FreshRedis
 
     def fhset(key, hash_key, value, options={})
       key = build_key(key, options)
-      @redis.multi do
-        @redis.hset(key.redis_key, hash_key, value)
-        @redis.expire(key.redis_key, key.freshness)
+      @redis.multi do |transaction|
+        transaction.hset(key.redis_key, hash_key, value)
+        transaction.expire(key.redis_key, key.freshness)
       end
     end
 

--- a/lib/fresh_redis/hash.rb
+++ b/lib/fresh_redis/hash.rb
@@ -12,11 +12,11 @@ class FreshRedis
     def fhget(key, hash_key, options={})
       key = build_key(key, options)
 
-      bucket_values = @redis.pipelined {
+      bucket_values = @redis.pipelined do |pipeline|
         key.timestamp_buckets.reverse.each do |bucket_key|
-          @redis.hget(bucket_key, hash_key)
+          pipeline.hget(bucket_key, hash_key)
         end
-      }
+      end
 
       # find the first non-nil value
       bucket_values.find{|e| e } 
@@ -25,11 +25,11 @@ class FreshRedis
     def fhgetall(key, options={})
       key = build_key(key, options)
 
-      bucket_values = @redis.pipelined {
+      bucket_values = @redis.pipelined do |pipeline|
         key.timestamp_buckets.each do |bucket_key|
-          @redis.hgetall(bucket_key)
+          pipeline.hgetall(bucket_key)
         end
-      }
+      end
 
       merged_values = bucket_values.inject({}){ |acc, bucket_hash|
         acc.merge(bucket_hash)
@@ -41,11 +41,11 @@ class FreshRedis
     def fhdel(key, hash_key, options={})
       key = build_key(key, options)
 
-      bucket_values = @redis.pipelined {
+      bucket_values = @redis.pipelined do |pipeline|
         key.timestamp_buckets.each do |bucket_key|
-          @redis.hdel(bucket_key, hash_key)
+          pipeline.hdel(bucket_key, hash_key)
         end
-      }
+      end
     end
   end
 end

--- a/lib/fresh_redis/set.rb
+++ b/lib/fresh_redis/set.rb
@@ -3,9 +3,9 @@ class FreshRedis
 
     def fsadd(key, value, options={})
       key = build_key(key, options)
-      @redis.multi do
-        @redis.sadd(key.redis_key, value)
-        @redis.expire(key.redis_key, key.freshness)
+      @redis.multi do |transaction|
+        transaction.sadd(key.redis_key, value)
+        transaction.expire(key.redis_key, key.freshness)
       end
     end
 

--- a/lib/fresh_redis/set.rb
+++ b/lib/fresh_redis/set.rb
@@ -12,11 +12,11 @@ class FreshRedis
     def fsmembers(key, options={})
       key = build_key(key, options)
 
-      bucket_values = @redis.pipelined {
+      bucket_values = @redis.pipelined do |pipeline|
         key.timestamp_buckets.reverse.each do |bucket_key|
-          @redis.smembers(bucket_key)
+          pipeline.smembers(bucket_key)
         end
-      }
+      end
 
       # find the first non-nil value
       bucket_values.flatten.uniq
@@ -25,11 +25,11 @@ class FreshRedis
     def fsismembers(key, value, options={})
       key = build_key(key, options)
 
-      bucket_values = @redis.pipelined {
+      bucket_values = @redis.pipelined do |pipeline|
         key.timestamp_buckets.reverse.each do |bucket_key|
-          return true if @redis.sismembers(bucket_key, value)
+          return true if pipeline.sismembers(bucket_key, value)
         end
-      }
+      end
 
       # find the first non-nil value
       return false
@@ -38,11 +38,11 @@ class FreshRedis
     def fsrem(key, value, options={})
       key = build_key(key, options)
 
-      bucket_values = @redis.pipelined {
+      bucket_values = @redis.pipelined do |pipeline|
         key.timestamp_buckets.reverse.each do |bucket_key|
-          @redis.srem(bucket_key, value)
+          pipeline.srem(bucket_key, value)
         end
-      }
+      end
     end
   end
 end

--- a/lib/fresh_redis/string.rb
+++ b/lib/fresh_redis/string.rb
@@ -30,9 +30,9 @@ class FreshRedis
 
     def fsum(key, options={})
       key = build_key(key, options)
-      @redis.pipelined {
+      @redis.pipelined { |pipeline|
         key.timestamp_buckets.each do |bucket_key|
-          @redis.get(bucket_key)
+          pipeline.get(bucket_key)
         end
       }.reduce(0){|acc, value|
         value ? acc + value.to_f : acc

--- a/lib/fresh_redis/string.rb
+++ b/lib/fresh_redis/string.rb
@@ -2,9 +2,9 @@ class FreshRedis
   module String
     def fincrby(key, increment, options={})
       key = build_key(key, options)
-      @redis.multi do
-        @redis.incrby(key.redis_key, increment)
-        @redis.expire(key.redis_key, key.freshness)
+      @redis.multi do |transaction|
+        transaction.incrby(key.redis_key, increment)
+        transaction.expire(key.redis_key, key.freshness)
       end
     end
 
@@ -14,9 +14,9 @@ class FreshRedis
 
     def fincrbyfloat(key, increment, options={})
       key = build_key(key, options)
-      @redis.multi do
-        @redis.incrbyfloat(key.redis_key, increment)
-        @redis.expire(key.redis_key, key.freshness)
+      @redis.multi do |transaction|
+        transaction.incrbyfloat(key.redis_key, increment)
+        transaction.expire(key.redis_key, key.freshness)
       end
     end
 

--- a/spec/fresh_redis_spec.rb
+++ b/spec/fresh_redis_spec.rb
@@ -1,5 +1,7 @@
-require 'fresh_redis'
-require 'mock_redis'
+# frozen_string_literal: true
+
+require "fresh_redis"
+require "mock_redis"
 
 describe FreshRedis do
   let(:mock_redis) { MockRedis.new }
@@ -7,11 +9,13 @@ describe FreshRedis do
   describe "#build_key" do
     it "builds a new key based on custom options" do
       key = "key"
-      FreshRedis::Key.should_receive(:build).with("foo", :granularity => 111, :freshness => 222).and_return(key)
+      expect(FreshRedis::Key).to receive(:build).with("foo",
+                                                      hash_including(granularity: 111, freshness: 222))
+                                                .and_return(key)
 
-      fresh_redis = FreshRedis.new(mock_redis, :granularity => 111, :freshness => 222)
+      fresh_redis = FreshRedis.new(mock_redis, granularity: 111, freshness: 222)
 
-      fresh_redis.build_key("foo").should == key
+      expect(fresh_redis.build_key("foo")).to eq key
     end
 
     it "builds a new key no options if custom options not provided" do
@@ -20,8 +24,7 @@ describe FreshRedis do
 
       fresh_redis = FreshRedis.new(mock_redis)
 
-      fresh_redis.build_key("foo").should == key
+      expect(fresh_redis.build_key("foo")).to eq key
     end
-
   end
 end


### PR DESCRIPTION
#### Context

Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0, which means apps using this gem are spewing logs like this:

<details>
  <summary>Example logs</summary>

```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end

(called from /Users/paj/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/fresh_redis-0.1.0/lib/fresh_redis/string.rb:33:in `fsum'}
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end

(called from /Users/paj/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/fresh_redis-0.1.0/lib/fresh_redis/string.rb:33:in `fsum'}
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.multi do
  redis.get("key")
end

should be replaced by

redis.multi do |pipeline|
  pipeline.get("key")
end

(called from /Users/paj/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/fresh_redis-0.1.0/lib/fresh_redis/string.rb:5:in `fincrby'}
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end

(called from /Users/paj/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/fresh_redis-0.1.0/lib/fresh_redis/string.rb:33:in `fsum'}

```

</details>


#### Change

- Remove incompatible rspec config from project and leave this to the individual
- Unlock and update all gem dependencies
- Get specs running again
- Use `Redis#pipelined` with block
- Use transaction variable with `Redis#multi` in anticipation of the same happening here

#### Considerations

A new release would be nice, please!
